### PR TITLE
on_Select/on_init datatype dfixes

### DIFF
--- a/innobits v 1.1 logs/innobits v 1.1 logs 15032023 latest/retail/init.json
+++ b/innobits v 1.1 logs/innobits v 1.1 logs 15032023 latest/retail/init.json
@@ -1,0 +1,79 @@
+{
+    "context": {
+      "ttl": "PT30S",
+      "city": "std:080",
+      "action": "init",
+      "bap_id": "buyer-app-preprod.ondc.org",
+      "bpp_id": "biz.test.enstore.com",
+      "domain": "nic2004:52110",
+      "bap_uri": "https://buyer-app-preprod.ondc.org/protocol/v1",
+      "bpp_uri": "https://biz.test.enstore.com/ecc/ondc/retail-bpp",
+      "country": "IND",
+      "timestamp": "2023-03-15T16:54:47.915Z",
+      "message_id": "d94028a9-c752-400a-aa31-bf9abc84c5b9",
+      "core_version": "1.1.0",
+      "transaction_id": "e2780b93-e221-42ea-8a50-83fd501fd5c1"
+    },
+    "message": {
+      "order": {
+        "items": [
+          {
+            "id": "5988",
+            "quantity": {
+              "count": 6
+            },
+            "fulfillment_id": "FPA:699:express:258:33006"
+          }
+        ],
+        "billing": {
+          "name": "Darshan SR Sapphire",
+          "email": "darshan.s@innobits.com",
+          "phone": "8151000066",
+          "address": {
+            "city": "Bengaluru",
+            "name": "Darshan SR Sapphire",
+            "state": "Karnataka",
+            "country": "IND",
+            "building": "Bennigana Halli",
+            "locality": "M26+M6F, 1st A Cross Rd, East of NGEF Layout, Bennigana Halli, Bengaluru, Karnataka 560043",
+            "area_code": "560043"
+          },
+          "created_at": "2023-03-15T16:54:47.915Z",
+          "updated_at": "2023-03-15T16:54:47.915Z"
+        },
+        "provider": {
+          "id": "1016:699",
+          "locations": [
+            {
+              "id": "L:1016:699"
+            }
+          ]
+        },
+        "fulfillments": [
+          {
+            "id": "FPA:699:express:258:33006",
+            "end": {
+              "contact": {
+                "email": "darshan.s@innobits.com",
+                "phone": "8151000066"
+              },
+              "location": {
+                "gps": "13.032943, 77.630862",
+                "address": {
+                  "city": "Bengaluru",
+                  "name": "Darshan SR Sapphire",
+                  "state": "Karnataka",
+                  "country": "IND",
+                  "building": "Bennigana Halli",
+                  "locality": "M26+M6F, 1st A Cross Rd, East of NGEF Layout, Bennigana Halli, Bengaluru, Karnataka 560043",
+                  "area_code": "560043"
+                }
+              }
+            },
+            "type": "Delivery",
+            "tracking": true
+          }
+        ]
+      }
+    }
+  },

--- a/innobits v 1.1 logs/innobits v 1.1 logs 15032023 latest/retail/on_Select.json
+++ b/innobits v 1.1 logs/innobits v 1.1 logs 15032023 latest/retail/on_Select.json
@@ -1,0 +1,102 @@
+{
+    "context": {
+      "ttl": "PT30S",
+      "city": "std:080",
+      "action": "on_select",
+      "bap_id": "buyer-app-preprod.ondc.org",
+      "bpp_id": "biz.test.enstore.com",
+      "domain": "nic2004:52110",
+      "bap_uri": "https://buyer-app-preprod.ondc.org/protocol/v1",
+      "bpp_uri": "https://biz.test.enstore.com/ecc/ondc/retail-bpp",
+      "country": "IND",
+      "timestamp": "2023-03-15T16:54:43.298Z",
+      "message_id": "1b432bb4-c6c6-4ba3-ac5a-368cf8378596",
+      "core_version": "1.1.0",
+      "transaction_id": "e2780b93-e221-42ea-8a50-83fd501fd5c1"
+    },
+    "message": {
+      "order": {
+        "items": [
+          {
+            "id": "5988",
+            "fulfillment_id": "FPA:699:express:258:33006"
+          }
+        ],
+        "quote": {
+          "ttl": "PT1H",
+          "price": {
+            "value": "3180.0",
+            "currency": "INR"
+          },
+          "breakup": [
+            {
+              "price": {
+                "value": "0.0",
+                "currency": "INR"
+              },
+              "title": "Tax",
+              "@ondc/org/item_id": "5988",
+              "@ondc/org/title_type": "tax"
+            },
+            {
+              "item": {
+                "count": 6,
+                "price": {
+                  "value": "530.0",
+                  "currency": "INR"
+                },
+                "quantity": {
+                  "maximum": {
+                    "count": "24"
+                  },
+                  "available": {
+                    "count": "24"
+                  }
+                }
+              },
+              "price": {
+                "value": "3180.0",
+                "currency": "INR"
+              },
+              "title": "Amul Ghee Pouch",
+              "@ondc/org/item_id": "5988",
+              "@ondc/org/title_type": "item",
+              "@ondc/org/item_quantity": {
+                "count": 6.0
+              }
+            },
+            {
+              "price": {
+                "value": 0,
+                "currency": "INR"
+              },
+              "title": "Delivery charges",
+              "@ondc/org/item_id": "FPA:699:express:258:33006",
+              "@ondc/org/title_type": "delivery"
+            }
+          ]
+        },
+        "provider": {
+          "id": "1016:699"
+        },
+        "fulfillments": [
+          {
+            "id": "FPA:699:express:258:33006",
+            "state": {
+              "descriptor": {
+                "code": "Serviceable",
+                "name": "Serviceable"
+              }
+            },
+            "tracking": true,
+            "@ondc/org/TAT": "PT1H",
+            "@ondc/org/category": "Immediate Delivery",
+            "@ondc/org/provider_name": "ondc-preprod.loadshare.net"
+          }
+        ],
+        "provider_location": {
+          "id": "1016:699"
+        }
+      }
+    }
+  }

--- a/innobits v 1.1 logs/innobits v 1.1 logs 15032023 latest/retail/on_init.json
+++ b/innobits v 1.1 logs/innobits v 1.1 logs 15032023 latest/retail/on_init.json
@@ -1,0 +1,147 @@
+{
+    "context": {
+      "ttl": "PT30S",
+      "city": "std:080",
+      "action": "on_init",
+      "bap_id": "buyer-app-preprod.ondc.org",
+      "bpp_id": "biz.test.enstore.com",
+      "domain": "nic2004:52110",
+      "bap_uri": "https://buyer-app-preprod.ondc.org/protocol/v1",
+      "bpp_uri": "https://biz.test.enstore.com/ecc/ondc/retail-bpp",
+      "country": "IND",
+      "timestamp": "2023-03-15T16:54:50.273Z",
+      "message_id": "d94028a9-c752-400a-aa31-bf9abc84c5b9",
+      "core_version": "1.1.0",
+      "transaction_id": "e2780b93-e221-42ea-8a50-83fd501fd5c1"
+    },
+    "message": {
+      "order": {
+        "items": [
+          {
+            "id": "5988",
+            "quantity": {
+              "count": 6
+            },
+            "fulfillment_id": "FPA:699:express:258:33006"
+          }
+        ],
+        "quote": {
+          "ttl": "PT1H",
+          "price": {
+            "value": "3180.0",
+            "currency": "INR"
+          },
+          "breakup": [
+            {
+              "price": {
+                "value": "0.0",
+                "currency": "INR"
+              },
+              "title": "Tax",
+              "@ondc/org/item_id": "5988",
+              "@ondc/org/title_type": "tax"
+            },
+            {
+              "item": {
+                "count": 6,
+                "price": {
+                  "value": "530.0",
+                  "currency": "INR"
+                },
+                "quantity": {
+                  "maximum": {
+                    "count": "24"
+                  },
+                  "available": {
+                    "count": "24"
+                  }
+                }
+              },
+              "price": {
+                "value": "3180.0",
+                "currency": "INR"
+              },
+              "title": "Amul Ghee Pouch",
+              "@ondc/org/item_id": "5988",
+              "@ondc/org/title_type": "item",
+              "@ondc/org/item_quantity": {
+                "count": 6.0
+              }
+            },
+            {
+              "price": {
+                "value": 0,
+                "currency": "INR"
+              },
+              "title": "Delivery charges",
+              "@ondc/org/item_id": "FPA:699:express:258:33006",
+              "@ondc/org/title_type": "delivery"
+            }
+          ]
+        },
+        "billing": {
+          "name": "Darshan SR Sapphire",
+          "email": "darshan.s@innobits.com",
+          "phone": "8151000066",
+          "address": {
+            "city": "Bengaluru",
+            "name": "Darshan SR Sapphire",
+            "state": "Karnataka",
+            "country": "IND",
+            "building": "Bennigana Halli",
+            "locality": "M26+M6F, 1st A Cross Rd, East of NGEF Layout, Bennigana Halli, Bengaluru, Karnataka 560043",
+            "area_code": "560043"
+          },
+          "created_at": "2023-03-15T16:54:47.915Z",
+          "updated_at": "2023-03-15T16:54:47.915Z"
+        },
+        "payment": {
+          "@ondc/org/settlement_details": [
+            {
+              "bank_name": "Axis Bank",
+              "branch_name": "Kathriguppe",
+              "settlement_type": "rtgs",
+              "beneficiary_name": "Innobits Solutions Pvt Ltd Nodal Account",
+              "settlement_phase": "sale-amount",
+              "settlement_ifsc_code": "UTIB0003190",
+              "settlement_counterparty": "seller-app",
+              "settlement_bank_account_no": "922020043291840"
+            }
+          ],
+          "@ondc/org/buyer_app_finder_fee_type": "percent",
+          "@ondc/org/buyer_app_finder_fee_amount": "3.0"
+        },
+        "provider": {
+          "id": "1016:699"
+        },
+        "fulfillments": [
+          {
+            "id": "FPA:699:express:258:33006",
+            "end": {
+              "contact": {
+                "email": "darshan.s@innobits.com",
+                "phone": "8151000066"
+              },
+              "location": {
+                "gps": "13.032943, 77.630862",
+                "address": {
+                  "city": "Bengaluru",
+                  "name": "Darshan SR Sapphire",
+                  "state": "Karnataka",
+                  "country": "IND",
+                  "building": "Bennigana Halli",
+                  "locality": "M26+M6F, 1st A Cross Rd, East of NGEF Layout, Bennigana Halli, Bengaluru, Karnataka 560043",
+                  "area_code": "560043"
+                }
+              }
+            },
+            "type": "Delivery",
+            "tracking": true
+          }
+        ],
+        "provider_location": {
+          "id": "1016:699"
+        }
+      }
+    }
+  }

--- a/innobits v 1.1 logs/innobits v 1.1 logs 15032023 latest/retail/select.json
+++ b/innobits v 1.1 logs/innobits v 1.1 logs 15032023 latest/retail/select.json
@@ -1,0 +1,56 @@
+{
+    "context": {
+      "ttl": "PT30S",
+      "city": "std:080",
+      "action": "select",
+      "bap_id": "buyer-app-preprod.ondc.org",
+      "bpp_id": "biz.test.enstore.com",
+      "domain": "nic2004:52110",
+      "bap_uri": "https://buyer-app-preprod.ondc.org/protocol/v1",
+      "bpp_uri": "https://biz.test.enstore.com/ecc/ondc/retail-bpp",
+      "country": "IND",
+      "timestamp": "2023-03-15T16:54:41.781Z",
+      "message_id": "1b432bb4-c6c6-4ba3-ac5a-368cf8378596",
+      "core_version": "1.1.0",
+      "transaction_id": "e2780b93-e221-42ea-8a50-83fd501fd5c1"
+    },
+    "message": {
+      "order": {
+        "items": [
+          {
+            "id": "5988",
+            "quantity": {
+              "count": 6
+            },
+            "location_id": "L:1016:699"
+          }
+        ],
+        "provider": {
+          "id": "1016:699",
+          "locations": [
+            {
+              "id": "L:1016:699"
+            }
+          ]
+        },
+        "fulfillments": [
+          {
+            "end": {
+              "location": {
+                "gps": "12.9140160000001, 77.6371740000001",
+                "address": {
+                  "area_code": "560102"
+                }
+              }
+            },
+            "state": {
+              "descriptor": {
+                "code": "Serviceable",
+                "name": "Serviceable"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },


### PR DESCRIPTION
@BLR-0118 submitted on_Select/on_init datatype fixes

on_Search all these are because of pre-prod, on prod we have rich data mapped to corresponding categories as per the contract

also as EAN code is mandatory we have mapped "1:0066" static code to the items, and this is only for pre-prod, prod will have uniq ean code mapped